### PR TITLE
Add detection for *.gsh, *.fsh, and *.vsh file name extensions

### DIFF
--- a/ftdetect/glsl.vim
+++ b/ftdetect/glsl.vim
@@ -3,6 +3,6 @@
 " Maintainer:	Sergey Tikhomirov <me@stikhomirov.com>
 " Last Change:	2012 July 10
 
-autocmd BufNewFile,BufRead *.geom,*.vert,*.frag set filetype=glsl
+autocmd BufNewFile,BufRead *.geom,*.vert,*.frag,*.gsh,*.vsh,*.fsh set filetype=glsl
 
 " vim:set sw=2:


### PR DESCRIPTION
This patch adds support for an alternative set of file extensions used for GLSL shaders.
