### PR TITLE
use autocmd! so that *.fs is not forth AND glsl

### DIFF
--- a/ftdetect/glsl.vim
+++ b/ftdetect/glsl.vim
@@ -1,6 +1,6 @@
 " Language: OpenGL Shading Language
 " Maintainer: Sergey Tikhomirov <sergey@tikhomirov.io>
 
-autocmd BufNewFile,BufRead *.glsl,*.geom,*.vert,*.frag,*.gsh,*.vsh,*.fsh,*.vs,*.fs set filetype=glsl
+autocmd! BufNewFile,BufRead *.glsl,*.geom,*.vert,*.frag,*.gsh,*.vsh,*.fsh,*.vs,*.fs set filetype=glsl
 
 " vim:set sts=2 sw=2 :


### PR DESCRIPTION
*.fs is setf forth in filetype.vim
https://github.com/nschloe/vim/blob/3cd009196341948f0730fe9f42859660bf759093/runtime/filetype.vim#L751-L752

Forth syntax sets iskeyword to very permissive values, since I think pretty much all non-whitespace is valid in forth identifiers.

This commit overwrites *.fs to be glsl only.
