### PR TITLE
highlight files with `.glsl` extension

### DIFF
--- a/ftdetect/glsl.vim
+++ b/ftdetect/glsl.vim
@@ -1,7 +1,7 @@
 " Language: OpenGL Shading Language
 " Maintainer: Sergey Tikhomirov <sergey@tikhomirov.io>
 
-" Extensions supported by Khronos reference compiler
+" Extensions supported by Khronos reference compiler (with one exception, ".glsl")
 " https://github.com/KhronosGroup/glslang
 autocmd! BufNewFile,BufRead *.vert,*.tesc,*.tese,*.glsl,*.geom,*.frag,*.comp set filetype=glsl
 

--- a/ftdetect/glsl.vim
+++ b/ftdetect/glsl.vim
@@ -3,6 +3,6 @@
 
 " Extensions supported by Khronos reference compiler
 " https://github.com/KhronosGroup/glslang
-autocmd! BufNewFile,BufRead *.vert,*.tesc,*.tese,*.geom,*.frag,*.comp set filetype=glsl
+autocmd! BufNewFile,BufRead *.vert,*.tesc,*.tese,*.glsl,*.geom,*.frag,*.comp set filetype=glsl
 
 " vim:set sts=2 sw=2 :


### PR DESCRIPTION
many projects use `.glsl` as an extension for their glsl code.

this resolves #13 – I think the question stated by the commit referenced there ( "do we _only_ support the extensions explicitly called out by Khronos?" ) is very interesting, but given how many shaders exist out there with the `.glsl` extension, I think it is reasonable to re-add support for it.

In my research, I also found the file that github's own language detection uses to decide whether or not a file extension means the file is a given language, including GLSL. here is that list of extensions for GLSL: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L1375-L1395