### PR TITLE
Enable auto-format of multiline comments

### DIFF
--- a/indent/glsl.vim
+++ b/indent/glsl.vim
@@ -6,5 +6,6 @@ if exists("b:did_indent")
 endif
 
 setlocal autoindent cindent
+setlocal formatoptions+=roq
 
 " vim:set sts=2 sw=2 :


### PR DESCRIPTION
This adds the `r`, `o`, and `q` format options which allow automatic insertion of the comment leader character in multiline comments. See `:help fo-table` for details on these options (they're all related to wrapping/leader-insertion for multiline comments).