### PR TITLE
Added containedin=javaScript to html syntax region

### DIFF
--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -5,5 +5,7 @@ syn include @GLSL syntax/glsl.vim
 syn region ShaderScript
       \ start="<script [^>]*type=\('\|\"\)x-shader/x-\(vertex\|fragment\)\('\|\"\)[^>]*>"
       \ keepend
+      \ containedin=javaScript
+      \ contained
       \ end="</script>"me=s-1
       \ contains=@GLSL,htmlScriptTag,@htmlPreproc


### PR DESCRIPTION
I was suprised to find when I started digging that this plugin alreadyhas a syntax region for html, since it didn't actually work for me. After investigating what was going on using [this](https://vim.fandom.com/wiki/Identify_the_syntax_highlighting_group_used_at_the_cursor), I came to the realization that the html plugin was already highlighting the content within script tags as JavaScript, and that this was taking priority over glsl highlighting that this plugin does.

Well, according to [this StackOverflow answer](https://vim.fandom.com/wiki/Identify_the_syntax_highlighting_group_used_at_the_cursor), you can beat such priority conflicts by telling vim that this group (`ShaderScript`) is `containedin` another group (`javaScript`). This appears to have solved the problem for me.
