### PR TITLE
Highlight builtin `gl_VertexIndex`

### DIFF
--- a/syntax/glsl.vim
+++ b/syntax/glsl.vim
@@ -450,6 +450,7 @@ syn keyword glslBuiltinVariable gl_TextureMatrixInverseTranspose
 syn keyword glslBuiltinVariable gl_TextureMatrixTranspose
 syn keyword glslBuiltinVariable gl_Vertex
 syn keyword glslBuiltinVariable gl_VertexID
+syn keyword glslBuiltinVariable gl_VertexIndex
 syn keyword glslBuiltinVariable gl_ViewportIndex
 syn keyword glslBuiltinVariable gl_WorkGroupID
 syn keyword glslBuiltinVariable gl_WorkGroupSize


### PR DESCRIPTION
`gl_VertexIndex` is part of the Vulkan only [GL_KHR_vulkan_glsl](https://github.com/KhronosGroup/GLSL/blob/master/extensions/khr/GL_KHR_vulkan_glsl.txt) extension.