### PR TITLE
Add ray tracing related keywords and file types

### DIFF
--- a/ftdetect/glsl.vim
+++ b/ftdetect/glsl.vim
@@ -3,6 +3,6 @@
 
 " Extensions supported by Khronos reference compiler (with one exception, ".glsl")
 " https://github.com/KhronosGroup/glslang
-autocmd! BufNewFile,BufRead *.vert,*.tesc,*.tese,*.glsl,*.geom,*.frag,*.comp set filetype=glsl
+autocmd! BufNewFile,BufRead *.vert,*.tesc,*.tese,*.glsl,*.geom,*.frag,*.comp,*.rgen,*.rmiss,*.rchit,*.rahit,*.rint,*.rcall set filetype=glsl
 
 " vim:set sts=2 sw=2 :

--- a/syntax/glsl.vim
+++ b/syntax/glsl.vim
@@ -47,6 +47,7 @@ syn keyword glslStructure struct nextgroup=glslIdentifier skipwhite skipempty
 syn match glslIdentifier contains=glslIdentifierPrime "\%([a-zA-Z_]\)\%([a-zA-Z0-9_]\)*" display contained
 
 " Types
+syn keyword glslType accelerationStructureEXT
 syn keyword glslType atomic_uint
 syn keyword glslType bool
 syn keyword glslType bvec2
@@ -118,6 +119,7 @@ syn keyword glslType mat4
 syn keyword glslType mat4x2
 syn keyword glslType mat4x3
 syn keyword glslType mat4x4
+syn keyword glslType rayQueryEXT
 syn keyword glslType sampler1D
 syn keyword glslType sampler1DArray
 syn keyword glslType sampler1DArrayShadow
@@ -172,6 +174,8 @@ syn keyword glslQualifier align
 syn keyword glslQualifier attribute
 syn keyword glslQualifier binding
 syn keyword glslQualifier buffer
+syn keyword glslQualifier callableDataEXT
+syn keyword glslQualifier callableDataInEXT
 syn keyword glslQualifier ccw
 syn keyword glslQualifier centroid
 syn keyword glslQualifier centroid varying
@@ -189,6 +193,7 @@ syn keyword glslQualifier flat
 syn keyword glslQualifier fractional_even_spacing
 syn keyword glslQualifier fractional_odd_spacing
 syn keyword glslQualifier highp
+syn keyword glslQualifier hitAttributeEXT
 syn keyword glslQualifier in
 syn keyword glslQualifier index
 syn keyword glslQualifier inout
@@ -206,6 +211,7 @@ syn keyword glslQualifier location
 syn keyword glslQualifier lowp
 syn keyword glslQualifier max_vertices
 syn keyword glslQualifier mediump
+syn keyword glslQualifier nonuniformEXT
 syn keyword glslQualifier noperspective
 syn keyword glslQualifier offset
 syn keyword glslQualifier origin_upper_left
@@ -231,6 +237,8 @@ syn keyword glslQualifier r8
 syn keyword glslQualifier r8_snorm
 syn keyword glslQualifier r8i
 syn keyword glslQualifier r8ui
+syn keyword glslQualifier rayPayloadEXT
+syn keyword glslQualifier rayPayloadInEXT
 syn keyword glslQualifier readonly
 syn keyword glslQualifier restrict
 syn keyword glslQualifier rg16
@@ -261,6 +269,7 @@ syn keyword glslQualifier rgba8i
 syn keyword glslQualifier rgba8ui
 syn keyword glslQualifier row_major
 syn keyword glslQualifier sample
+syn keyword glslQualifier shaderRecordEXT
 syn keyword glslQualifier shared
 syn keyword glslQualifier smooth
 syn keyword glslQualifier std140
@@ -275,11 +284,13 @@ syn keyword glslQualifier vertices
 syn keyword glslQualifier volatile
 syn keyword glslQualifier writeonly
 syn keyword glslQualifier xfb_buffer
-syn keyword glslQualifier xfb_stride
 syn keyword glslQualifier xfb_offset
+syn keyword glslQualifier xfb_stride
 
 " Built-in Constants
 syn keyword glslBuiltinConstant gl_CullDistance
+syn keyword glslBuiltinConstant gl_HitKindBackFacingTriangleEXT
+syn keyword glslBuiltinConstant gl_HitKindFrontFacingTriangleEXT
 syn keyword glslBuiltinConstant gl_MaxAtomicCounterBindings
 syn keyword glslBuiltinConstant gl_MaxAtomicCounterBufferSize
 syn keyword glslBuiltinConstant gl_MaxClipDistances
@@ -359,6 +370,20 @@ syn keyword glslBuiltinConstant gl_MaxVertexUniformComponents
 syn keyword glslBuiltinConstant gl_MaxVertexUniformVectors
 syn keyword glslBuiltinConstant gl_MaxViewports
 syn keyword glslBuiltinConstant gl_MinProgramTexelOffset
+syn keyword glslBuiltinConstant gl_RayFlagsCullBackFacingTrianglesEXT
+syn keyword glslBuiltinConstant gl_RayFlagsCullFrontFacingTrianglesEXT
+syn keyword glslBuiltinConstant gl_RayFlagsCullNoOpaqueEXT
+syn keyword glslBuiltinConstant gl_RayFlagsCullOpaqueEXT
+syn keyword glslBuiltinConstant gl_RayFlagsNoOpaqueEXT
+syn keyword glslBuiltinConstant gl_RayFlagsNoneEXT
+syn keyword glslBuiltinConstant gl_RayFlagsOpaqueEXT
+syn keyword glslBuiltinConstant gl_RayFlagsSkipClosestHitShaderEXT
+syn keyword glslBuiltinConstant gl_RayFlagsTerminateOnFirstHitEXT
+syn keyword glslBuiltinConstant gl_RayQueryCandidateIntersectionAABBEXT
+syn keyword glslBuiltinConstant gl_RayQueryCandidateIntersectionTriangleEXT
+syn keyword glslBuiltinConstant gl_RayQueryCommittedIntersectionGeneratedEXT
+syn keyword glslBuiltinConstant gl_RayQueryCommittedIntersectionNoneEXT
+syn keyword glslBuiltinConstant gl_RayQueryCommittedIntersectionTriangleEXT
 
 " Built-in Variables
 syn keyword glslBuiltinVariable gl_BackColor
@@ -389,10 +414,18 @@ syn keyword glslBuiltinVariable gl_FrontLightModelProduct
 syn keyword glslBuiltinVariable gl_FrontLightProduct
 syn keyword glslBuiltinVariable gl_FrontMaterial
 syn keyword glslBuiltinVariable gl_FrontSecondaryColor
+syn keyword glslBuiltinVariable gl_GeometryIndexEXT
 syn keyword glslBuiltinVariable gl_GlobalInvocationID
 syn keyword glslBuiltinVariable gl_HelperInvocation
+syn keyword glslBuiltinVariable gl_HitKindEXT
+syn keyword glslBuiltinVariable gl_HitTEXT
+syn keyword glslBuiltinVariable gl_IncomingRayFlagsEXT
+syn keyword glslBuiltinVariable gl_InstanceCustomIndexEXT
+syn keyword glslBuiltinVariable gl_InstanceID
 syn keyword glslBuiltinVariable gl_InstanceID
 syn keyword glslBuiltinVariable gl_InvocationID
+syn keyword glslBuiltinVariable gl_LaunchIDEXT
+syn keyword glslBuiltinVariable gl_LaunchSizeEXT
 syn keyword glslBuiltinVariable gl_Layer
 syn keyword glslBuiltinVariable gl_LightModel
 syn keyword glslBuiltinVariable gl_LightSource
@@ -423,17 +456,24 @@ syn keyword glslBuiltinVariable gl_ObjectPlaneQ
 syn keyword glslBuiltinVariable gl_ObjectPlaneR
 syn keyword glslBuiltinVariable gl_ObjectPlaneS
 syn keyword glslBuiltinVariable gl_ObjectPlaneT
+syn keyword glslBuiltinVariable gl_ObjectRayDirectionEXT
+syn keyword glslBuiltinVariable gl_ObjectRayOriginEXT
+syn keyword glslBuiltinVariable gl_ObjectToWorld3x4EXT
+syn keyword glslBuiltinVariable gl_ObjectToWorldEXT
 syn keyword glslBuiltinVariable gl_PatchVerticesIn
 syn keyword glslBuiltinVariable gl_Point
 syn keyword glslBuiltinVariable gl_PointCoord
 syn keyword glslBuiltinVariable gl_PointSize
 syn keyword glslBuiltinVariable gl_Position
 syn keyword glslBuiltinVariable gl_PrimitiveID
+syn keyword glslBuiltinVariable gl_PrimitiveID
 syn keyword glslBuiltinVariable gl_PrimitiveIDIn
 syn keyword glslBuiltinVariable gl_ProjectionMatrix
 syn keyword glslBuiltinVariable gl_ProjectionMatrixInverse
 syn keyword glslBuiltinVariable gl_ProjectionMatrixInverseTranspose
 syn keyword glslBuiltinVariable gl_ProjectionMatrixTranspose
+syn keyword glslBuiltinVariable gl_RayTmaxEXT
+syn keyword glslBuiltinVariable gl_RayTminEXT
 syn keyword glslBuiltinVariable gl_SampleID
 syn keyword glslBuiltinVariable gl_SampleMask
 syn keyword glslBuiltinVariable gl_SampleMaskIn
@@ -454,6 +494,10 @@ syn keyword glslBuiltinVariable gl_VertexIndex
 syn keyword glslBuiltinVariable gl_ViewportIndex
 syn keyword glslBuiltinVariable gl_WorkGroupID
 syn keyword glslBuiltinVariable gl_WorkGroupSize
+syn keyword glslBuiltinVariable gl_WorldRayDirectionEXT
+syn keyword glslBuiltinVariable gl_WorldRayOriginEXT
+syn keyword glslBuiltinVariable gl_WorldToObject3x4EXT
+syn keyword glslBuiltinVariable gl_WorldToObjectEXT
 syn keyword glslBuiltinVariable gl_in
 syn keyword glslBuiltinVariable gl_out
 
@@ -503,6 +547,7 @@ syn keyword glslBuiltinFunction determinant
 syn keyword glslBuiltinFunction distance
 syn keyword glslBuiltinFunction dot
 syn keyword glslBuiltinFunction equal
+syn keyword glslBuiltinFunction executeCallableEXT
 syn keyword glslBuiltinFunction exp
 syn keyword glslBuiltinFunction exp2
 syn keyword glslBuiltinFunction faceforward
@@ -521,6 +566,7 @@ syn keyword glslBuiltinFunction fwidthFine
 syn keyword glslBuiltinFunction greaterThan
 syn keyword glslBuiltinFunction greaterThanEqual
 syn keyword glslBuiltinFunction groupMemoryBarrier
+syn keyword glslBuiltinFunction ignoreIntersectionEXT
 syn keyword glslBuiltinFunction imageAtomicAdd
 syn keyword glslBuiltinFunction imageAtomicAnd
 syn keyword glslBuiltinFunction imageAtomicCompSwap
@@ -574,8 +620,32 @@ syn keyword glslBuiltinFunction packUnorm2x16
 syn keyword glslBuiltinFunction packUnorm4x8
 syn keyword glslBuiltinFunction pow
 syn keyword glslBuiltinFunction radians
+syn keyword glslBuiltinFunction rayQueryConfirmIntersectionEXT
+syn keyword glslBuiltinFunction rayQueryGenerateIntersectionEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionBarycentricsEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionCandidateAABBOpaqueEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionFrontFaceEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionGeometryIndexEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionInstanceCustomIndexEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionInstanceIdEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionObjectRayDirectionEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionObjectRayOriginEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionObjectToWorldEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionPrimitiveIndexEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionTEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionTypeEXT
+syn keyword glslBuiltinFunction rayQueryGetIntersectionWorldToObjectEXT
+syn keyword glslBuiltinFunction rayQueryGetRayFlagsEXT
+syn keyword glslBuiltinFunction rayQueryGetRayTMinEXT
+syn keyword glslBuiltinFunction rayQueryGetWorldRayDirectionEXT
+syn keyword glslBuiltinFunction rayQueryGetWorldRayOriginEXT
+syn keyword glslBuiltinFunction rayQueryInitializeEXT
+syn keyword glslBuiltinFunction rayQueryProceedEXT
+syn keyword glslBuiltinFunction rayQueryTerminateEXT
 syn keyword glslBuiltinFunction reflect
 syn keyword glslBuiltinFunction refract
+syn keyword glslBuiltinFunction reportIntersectionEXT
 syn keyword glslBuiltinFunction round
 syn keyword glslBuiltinFunction roundEven
 syn keyword glslBuiltinFunction shadow1D
@@ -594,6 +664,7 @@ syn keyword glslBuiltinFunction sqrt
 syn keyword glslBuiltinFunction step
 syn keyword glslBuiltinFunction tan
 syn keyword glslBuiltinFunction tanh
+syn keyword glslBuiltinFunction terminateRayEXT
 syn keyword glslBuiltinFunction texelFetch
 syn keyword glslBuiltinFunction texelFetchOffset
 syn keyword glslBuiltinFunction texture
@@ -628,6 +699,7 @@ syn keyword glslBuiltinFunction textureProjOffset
 syn keyword glslBuiltinFunction textureQueryLevels
 syn keyword glslBuiltinFunction textureQueryLod
 syn keyword glslBuiltinFunction textureSize
+syn keyword glslBuiltinFunction traceRayEXT
 syn keyword glslBuiltinFunction transpose
 syn keyword glslBuiltinFunction trunc
 syn keyword glslBuiltinFunction uaddCarry


### PR DESCRIPTION
Add highlights for keywords, functions, variables and constants
introduced by extensions:
- GLSL_EXT_ray_tracing
- GLSL_EXT_ray_query
- GL_EXT_nonuniform_qualifier

Also add filetypes for ray tracing stages:
- *.rgen for ray generation shader
- *.rmiss for ray miss shader
- *.rint for intersection shader
- *.rahit for any hit shader
- *.rchit for closest hit shader
- *.rcall for callable shader