### PR TITLE
Ensure cinoptions is set to a known value

### DIFF
--- a/indent/glsl.vim
+++ b/indent/glsl.vim
@@ -7,5 +7,6 @@ endif
 
 setlocal autoindent cindent
 setlocal formatoptions+=roq
+setlocal cinoptions&
 
 " vim:set sts=2 sw=2 :


### PR DESCRIPTION
Fix `set cinoptions=#1` causes incorrect define indenting.

To get correct glsl indentation, we want default 'cinoptions'. It's useful to
`set cinoptions=#1` (to allow most filetypes to use # comments), so we should
ensure we're using a known set of indent options and revert to the default.

The user can still customize cinoptions in ~/.vim/after/indent/glsl.vim.

## Test
```vim
:set cinoptions=#1
:edit test.glsl
gg=G
```

```glsl
// test.glsl
#define PI 4
#define TAU 8 // line gets 1 space indent

float f(float x) {
	return x * 2;
}
```