### PR TITLE
Support #include

### DIFF
--- a/syntax/glsl.vim
+++ b/syntax/glsl.vim
@@ -21,6 +21,7 @@ syn region  glslDefine          start="^\s*#\s*\(define\|undef\)" skip="\\$" end
 syn keyword glslTokenConcat     ##
 syn keyword glslPredefinedMacro __LINE__ __FILE__ __VERSION__ GL_ES
 syn region  glslPreProc         start="^\s*#\s*\(error\|pragma\|extension\|version\|line\)" skip="\\$" end="$" keepend
+syn region  glslInclude         start="^\s*#\s*include" skip="\\$" end="$" keepend
 
 " Boolean Constants
 syn keyword glslBoolean true false
@@ -725,6 +726,7 @@ hi def link glslDefine          Define
 hi def link glslTokenConcat     glslPreProc
 hi def link glslPredefinedMacro Macro
 hi def link glslPreProc         PreProc
+hi def link glslInclude         Include
 hi def link glslBoolean         Boolean
 hi def link glslDecimalInt      glslInteger
 hi def link glslOctalInt        glslInteger


### PR DESCRIPTION
Core Khronos GLSL ignores `#include`.

The reality is that engines which load GLSL at runtime (OpenGL, GLES) often invent their own preprocessing or runtime `#include` support, and shaderc, used by Vulkan engines, also supports `#include`.

Programmer-facing shader code will often have `#include`, so it's useful to highlight it.

This implementation is not as sophisticated as the upstream `c.vim`, but neither is the rest of the plugin anyway.