### PR TITLE
Add folding support for {} and ()

### DIFF
--- a/syntax/glsl.vim
+++ b/syntax/glsl.vim
@@ -22,6 +22,10 @@ syn keyword glslTokenConcat     ##
 syn keyword glslPredefinedMacro __LINE__ __FILE__ __VERSION__ GL_ES
 syn region  glslPreProc         start="^\s*#\s*\(error\|pragma\|extension\|version\|line\)" skip="\\$" end="$" keepend
 
+" Folding Blocks
+syn region glslCurlyBlock start="{" end="}" transparent fold
+syn region glslParenBlock start="(" end=")" transparent fold
+
 " Boolean Constants
 syn keyword glslBoolean true false
 


### PR DESCRIPTION
Right now, there doesn't seem to be any support for `fdm=syntax` in the plugin. I just added folding for:
- {} blocks - obvious
- () blocks - debatable, but IMO it's useful for tall multiline function calls with lots of arguments. I actually wish c.vim, rust.vim, etc. had this